### PR TITLE
Update [tag].astro - props type added

### DIFF
--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,4 +1,5 @@
 ---
+import type { CollectionEntry } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import BlogPost from "../../components/BlogPost.astro";
 
@@ -18,6 +19,10 @@ export async function getStaticPaths() {
       props: { posts: filteredPosts },
     };
   });
+}
+
+type Props = {
+  posts: CollectionEntry<'posts'>[];
 }
 
 const { tag } = Astro.params;


### PR DESCRIPTION
Add type for posts of Astro props.

Avoid error of `Parameter 'post' implicitly has an 'any' type.` for user doing tutorial with TS strict.