### PR TITLE
removes the "light" class from astro:page-swap

### DIFF
--- a/src/components/ThemeIcon.astro
+++ b/src/components/ThemeIcon.astro
@@ -75,6 +75,6 @@
   document.addEventListener('astro:after-swap', () => {
     localStorage.theme === 'dark' 
     ? document.documentElement.classList.add("dark")
-    : document.documentElement.classList.add("light");
+    : document.documentElement.classList.remove("dark");
   }); 
 </script>


### PR DESCRIPTION
When quickly moving between pages, you may notice that the class is "dark light". But class should be "dark" or "".

Steps:

1. Enable dark theme.
2. Change page
3. Turn off the dark theme without waiting for the page transition to complete.

