### PR TITLE
update for Astro v5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/preact": "^3.0.0",
-    "@astrojs/rss": "^3.0.0",
-    "astro": "^3.1.1",
+    "@astrojs/preact": "^4.0.0",
+    "@astrojs/rss": "^4.0.9",
+    "astro": "^5.0.0",
     "preact": "^10.11.3"
   }
 }

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -2,7 +2,7 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import BlogPost from "../components/BlogPost.astro";
 const pageTitle = "My Astro Learning Blog";
-const allPosts = await Astro.glob("../pages/posts/*.md");
+const allPosts = Object.values(await import.meta.glob('./posts/*.md', { eager: true }));
 ---
 
 <BaseLayout pageTitle={pageTitle}>

--- a/src/pages/posts/post-4.md
+++ b/src/pages/posts/post-4.md
@@ -9,4 +9,4 @@ image:
 pubDate: 2022-08-08
 tags: ["astro", "successes"]
 ---
-This post should show up with my other blog posts, because `Astro.glob()` is returning a list of all my posts in order to create my list.
+This post should show up with my other blog posts, because `import.meta.glob()` is returning a list of all my posts in order to create my list.

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -7,5 +7,5 @@ export async function GET(context) {
     site: context.site,
     items: await pagesGlobToRssItems(import.meta.glob('./**/*.md')),
     customData: `<language>en-us</language>`,
-  })
+  });
 }

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -3,7 +3,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import BlogPost from "../../components/BlogPost.astro";
 
 export async function getStaticPaths() {
-  const allPosts = await Astro.glob("../posts/*.md");
+  const allPosts = Object.values(await import.meta.glob('./posts/*.md', { eager: true }));
 
   const uniqueTags = [
     ...new Set(allPosts.map((post) => post.frontmatter.tags).flat()),

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -3,8 +3,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import BlogPost from "../../components/BlogPost.astro";
 
 export async function getStaticPaths() {
-  const allPosts = Object.values(await import.meta.glob('./posts/*.md', { eager: true }));
-
+  const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
   const uniqueTags = [
     ...new Set(allPosts.map((post:any) => post.frontmatter.tags).flat()),
   ];

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
-const allPosts = await Astro.glob("../posts/*.md");
+const allPosts = Object.values(await import.meta.glob('./posts/*.md', { eager: true }));
 const tags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())];
 const pageTitle = "Tag Index";
 ---

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
-const allPosts = Object.values(await import.meta.glob('./posts/*.md', { eager: true }));
+const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
 const tags = [...new Set(allPosts.map((post:any) => post.frontmatter.tags).flat())];
 const pageTitle = "Tag Index";
 ---


### PR DESCRIPTION
This PR updates the tutorial code for Astro v5.0 which deprecates `Astro.glob()` and uses `import.meta.glob()` instead.

Also updates for the new TypeScript default when using `create astro`.

This should not be merged until 5.0 is stable!