### PR TITLE
Content-collections-v5: fix Typescript errors in `ThemeIcon.astro`

### DIFF
--- a/src/components/ThemeIcon.astro
+++ b/src/components/ThemeIcon.astro
@@ -1,4 +1,5 @@
 ---
+
 ---
 
 <button id="themeToggle">
@@ -17,7 +18,7 @@
 </button>
 
 <style>
-   #themeToggle {
+  #themeToggle {
     border: 0;
     background: none;
   }
@@ -40,7 +41,7 @@
 <script>
   const theme = (() => {
     if (typeof localStorage !== "undefined" && localStorage.getItem("theme")) {
-      return localStorage.getItem("theme");
+      return localStorage.getItem("theme") ?? "light";
     }
     if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
       return "dark";
@@ -66,5 +67,5 @@
 
   document
     .getElementById("themeToggle")
-    .addEventListener("click", handleToggleClick);
+    ?.addEventListener("click", handleToggleClick);
 </script>


### PR DESCRIPTION
As noted in #33, when opening the code for contents-collection v5, we had some Typescript errors in `src/components/ThemeIcon.astro`. This PR adds minor changes to make Typescript happy!

Note: this should be merged in Sarah's PR #33!