### PR TITLE
Update the complete branch to match the docs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 import { defineConfig } from "astro/config";
 
 import preact from "@astrojs/preact";
@@ -5,5 +6,5 @@ import preact from "@astrojs/preact";
 // https://astro.build/config
 export default defineConfig({
   site: "https://example.com",
-  integrations: [preact()]
+  integrations: [preact()],
 });

--- a/package.json
+++ b/package.json
@@ -5,15 +5,14 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/preact": "^4.0.0-beta.1",
-    "@astrojs/rss": "^4.0.9",
-    "astro": "^5.0.0-beta.12",
-    "preact": "^10.11.3"
+    "@astrojs/preact": "^4.0.2",
+    "@astrojs/rss": "^4.0.11",
+    "astro": "^5.1.7",
+    "preact": "^10.25.4"
   }
 }

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,15 +3,15 @@ import Social from "./Social.astro";
 ---
 
 <style>
-   footer {
-       display: flex;
-       gap: 0.5rem;
-       margin-top: 2rem;
-   }
+  footer {
+    display: flex;
+    gap: 1rem;
+    margin-top: 2rem;
+  }
 </style>
 
 <footer>
-    <Social platform="twitter" username="astrodotbuild" />
-    <Social platform="github" username="withastro" />
-    <Social platform="youtube" username="astrodotbuild" />
+  <Social platform="twitter" username="astrodotbuild" />
+  <Social platform="github" username="withastro" />
+  <Social platform="youtube" username="astrodotbuild" />
 </footer>

--- a/src/components/Greeting.jsx
+++ b/src/components/Greeting.jsx
@@ -1,13 +1,13 @@
 import { useState } from 'preact/hooks';
 
-export default function Greeting({messages}) {
+export default function Greeting({ messages }) {
 
   const randomMessage = () => messages[(Math.floor(Math.random() * messages.length))];
-  
+
   const [greeting, setGreeting] = useState(messages[0]);
 
   return (
-    <div> 
+    <div>
       <h3>{greeting}! Thank you for visiting!</h3>
       <button onClick={() => setGreeting(randomMessage())}>
         New Greeting

--- a/src/components/ThemeIcon.astro
+++ b/src/components/ThemeIcon.astro
@@ -1,4 +1,5 @@
 ---
+
 ---
 
 <button id="themeToggle">
@@ -17,7 +18,7 @@
 </button>
 
 <style>
-   #themeToggle {
+  #themeToggle {
     border: 0;
     background: none;
   }
@@ -39,8 +40,9 @@
 
 <script is:inline>
   const theme = (() => {
-    if (typeof localStorage !== "undefined" && localStorage.getItem("theme")) {
-      return localStorage.getItem("theme");
+    const localStorageTheme = localStorage?.getItem("theme") ?? "";
+    if (["dark", "light"].includes(localStorageTheme)) {
+      return localStorageTheme;
     }
     if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
       return "dark";
@@ -66,5 +68,5 @@
 
   document
     .getElementById("themeToggle")
-    .addEventListener("click", handleToggleClick);
+    ?.addEventListener("click", handleToggleClick);
 </script>

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -4,9 +4,41 @@ const { frontmatter } = Astro.props;
 ---
 
 <BaseLayout pageTitle={frontmatter.title}>
-  <p>{frontmatter.pubDate.slice(0, 10)}</p>
   <p><em>{frontmatter.description}</em></p>
+  <p>{frontmatter.pubDate.toString().slice(0, 10)}</p>
+
   <p>Written by: {frontmatter.author}</p>
+
   <img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} />
+
+  <div class="tags">
+    {
+      frontmatter.tags.map((tag: string) => (
+        <p class="tag">
+          <a href={`/tags/${tag}`}>{tag}</a>
+        </p>
+      ))
+    }
+  </div>
+
   <slot />
 </BaseLayout>
+<style>
+  a {
+    color: #00539f;
+  }
+
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .tag {
+    margin: 0.25em;
+    border: dotted 1px #a1a1a1;
+    border-radius: 0.5em;
+    padding: 0.5em 1em;
+    font-size: 1.15em;
+    background-color: #f8fcfd;
+  }
+</style>

--- a/src/pages/posts/post-1.md
+++ b/src/pages/posts/post-1.md
@@ -5,8 +5,8 @@ pubDate: 2022-07-01
 description: "This is the first post of my new Astro blog."
 author: "Astro Learner"
 image:
-  url: "https://docs.astro.build/assets/full-logo-light.png"
-  alt: "The Astro logo with the word One."
+  url: "https://docs.astro.build/assets/rose.webp"
+  alt: "The Astro logo on a dark background with a pink glow."
 tags: ["astro", "blogging", "learning in public"]
 ---
 

--- a/src/pages/posts/post-2.md
+++ b/src/pages/posts/post-2.md
@@ -5,7 +5,7 @@ author: Astro Learner
 description: "After learning some Astro, I couldn't stop!"
 image:
   url: "https://docs.astro.build/assets/arc.webp"
-  alt: "Thumbnails of websites from the Astro Showcase site."
+  alt: "The Astro logo on a dark background with a purple gradient arc."
 pubDate: 2022-07-08
 tags: ["astro", "blogging", "learning in public", "successes"]
 ---

--- a/src/pages/posts/post-3.md
+++ b/src/pages/posts/post-3.md
@@ -5,7 +5,7 @@ author: Astro Learner
 description: "I had some challenges, but asking in the community really helped!"
 image:
   url: "https://docs.astro.build/assets/rays.webp"
-  alt: "The word community with a heart."
+  alt: "The Astro logo on a dark background with rainbow rays."
 pubDate: 2022-07-15
 tags: ["astro", "learning in public", "setbacks", "community"]
 ---

--- a/src/pages/posts/post-4.md
+++ b/src/pages/posts/post-4.md
@@ -3,7 +3,7 @@ layout: ../../layouts/MarkdownPostLayout.astro
 title: My Fourth Blog Post
 author: Astro Learner
 description: "This post will show up on its own!"
-image: 
+image:
   url: "https://docs.astro.build/default-og-image.png"
   alt: "The word astro against an illustration of planets and stars."
 pubDate: 2022-08-08

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -3,13 +3,16 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
 import BlogPost from "../../components/BlogPost.astro";
 
 export async function getStaticPaths() {
-  const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
+  const allPosts = Object.values(
+    import.meta.glob("../posts/*.md", { eager: true })
+  );
+
   const uniqueTags = [
-    ...new Set(allPosts.map((post:any) => post.frontmatter.tags).flat()),
+    ...new Set(allPosts.map((post: any) => post.frontmatter.tags).flat()),
   ];
 
-  return uniqueTags.map((tag:string) => {
-    const filteredPosts = allPosts.filter((post:any) =>
+  return uniqueTags.map((tag) => {
+    const filteredPosts = allPosts.filter((post: any) =>
       post.frontmatter.tags.includes(tag)
     );
     return {
@@ -27,7 +30,7 @@ const { posts } = Astro.props;
   <p>Posts tagged with {tag}</p>
   <ul>
     {
-      posts.map((post:any) => (
+      posts.map((post: any) => (
         <BlogPost url={post.url} title={post.frontmatter.title} />
       ))
     }

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,14 +1,18 @@
 ---
 import BaseLayout from "../../layouts/BaseLayout.astro";
-const allPosts = Object.values(await import.meta.glob('../posts/*.md', { eager: true }));
-const tags = [...new Set(allPosts.map((post:any) => post.frontmatter.tags).flat())];
+const allPosts = Object.values(
+  import.meta.glob("../posts/*.md", { eager: true })
+);
+const tags = [
+  ...new Set(allPosts.map((post: any) => post.frontmatter.tags).flat()),
+];
 const pageTitle = "Tag Index";
 ---
 
 <BaseLayout pageTitle={pageTitle}>
   <div class="tags">
     {
-      tags.map((tag:string) => (
+      tags.map((tag) => (
         <p class="tag">
           <a href={`/tags/${tag}`}>{tag}</a>
         </p>
@@ -24,7 +28,6 @@ const pageTitle = "Tag Index";
   .tags {
     display: flex;
     flex-wrap: wrap;
-    margin: 0 auto;
   }
 
   .tag {


### PR DESCRIPTION
## Changes

I followed the [tutorial](https://docs.astro.build/en/tutorial/0-introduction/) in Astro Docs to check if we missed some updates. So here are the changes:

* Updates the dependencies (we were still using the beta version)
* Removes the `start` script which was removed with Astro 5
* Adds `@ts-check` in `astro.config.mjs` since this is now added by default when creating a new project
* Removes unnecessary `await` before `import.meta.glob`
* Updates the images URL and alt description in `src/pages/posts` (one image in particular was broken)
* Adds missing tags in `MarkdownPostLayout.astro`
* Removes some unnecessary types and styles (no longer in the docs)
* Converts the Greeting component to JSX (instead of TSX) to prevent a Typescript error and to match the extension used in the docs
* Adds a missing optional chaining operator in `ThemeIcon` component (alongside changes submitted in #38)

I disabled Prettier for the workspace but there was still some formatting when saving the files...

I'll do the same on the `content-collections` branch.