### PR TITLE
Update the `content-collections` branch to match docs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,9 +1,10 @@
+// @ts-check
 import { defineConfig } from "astro/config";
 
-// https://astro.build/config
 import preact from "@astrojs/preact";
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [preact()]
+  site: "https://example.com",
+  integrations: [preact()],
 });

--- a/package.json
+++ b/package.json
@@ -5,15 +5,14 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/preact": "^4.0.0-beta.1",
-    "@astrojs/rss": "^4.0.9",
-    "astro": "^5.0.0-beta.12",
-    "preact": "^10.11.3"
+    "@astrojs/preact": "^4.0.2",
+    "@astrojs/rss": "^4.0.11",
+    "astro": "^5.1.7",
+    "preact": "^10.25.4"
   }
 }

--- a/src/blog/post-1.md
+++ b/src/blog/post-1.md
@@ -1,17 +1,13 @@
 ---
-title: 'My First Blog Post'
+title: "My First Blog Post"
 pubDate: 2022-07-01
 description: "This is the first post of my new Astro blog."
 author: "Astro Learner"
 image:
-  url: "https://astro.build/assets/blog/astro-1-release-update/cover.jpeg"
-  alt: "The Astro logo with the word One."
+  url: "https://docs.astro.build/assets/rose.webp"
+  alt: "The Astro logo on a dark background with a pink glow."
 tags: ["astro", "blogging", "learning in public"]
 ---
-
-# My First Blog Post
-
-Published on: 2022-07-01
 
 Welcome to my _new blog_ about learning Astro! Here, I will share my learning journey as I build a new website.
 

--- a/src/blog/post-2.md
+++ b/src/blog/post-2.md
@@ -3,8 +3,8 @@ title: My Second Blog Post
 author: Astro Learner
 description: "After learning some Astro, I couldn't stop!"
 image:
-  url: "https://astro.build/assets/blog/astro-showcase/astro-showcase-screenshot.jpg"
-  alt: "Thumbnails of websites from the Astro Showcase site."
+  url: "https://docs.astro.build/assets/arc.webp"
+  alt: "The Astro logo on a dark background with a purple gradient arc."
 pubDate: 2022-07-08
 tags: ["astro", "blogging", "learning in public", "successes"]
 ---

--- a/src/blog/post-3.md
+++ b/src/blog/post-3.md
@@ -3,8 +3,8 @@ title: My Third Blog Post
 author: Astro Learner
 description: "I had some challenges, but asking in the community really helped!"
 image:
-  url: "https://astro.build/assets/blog/community-day/cover.jpg"
-  alt: "The word community with a heart."
+  url: "https://docs.astro.build/assets/rays.webp"
+  alt: "The Astro logo on a dark background with rainbow rays."
 pubDate: 2022-07-15
 tags: ["astro", "learning in public", "setbacks", "community"]
 ---

--- a/src/blog/post-4.md
+++ b/src/blog/post-4.md
@@ -2,10 +2,11 @@
 title: My Fourth Blog Post
 author: Astro Learner
 description: "This post will show up on its own!"
-image: 
+image:
   url: "https://docs.astro.build/default-og-image.png"
-  alt: "The word “astro” against an illustration of planets and stars."
+  alt: "The word astro against an illustration of planets and stars."
 pubDate: 2022-08-08
 tags: ["astro", "successes"]
 ---
+
 This post should show up with my other blog posts, because `import.meta.glob()` is returning a list of all my posts in order to create my list.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,15 +3,15 @@ import Social from "./Social.astro";
 ---
 
 <style>
-   footer {
-       display: flex;
-       gap: 0.5rem;
-       margin-top: 2rem;
-   }
+  footer {
+    display: flex;
+    gap: 1rem;
+    margin-top: 2rem;
+  }
 </style>
 
 <footer>
-    <Social platform="twitter" username="astrodotbuild" />
-    <Social platform="github" username="withastro" />
-    <Social platform="youtube" username="astrodotbuild" />
+  <Social platform="twitter" username="astrodotbuild" />
+  <Social platform="github" username="withastro" />
+  <Social platform="youtube" username="astrodotbuild" />
 </footer>

--- a/src/components/Greeting.jsx
+++ b/src/components/Greeting.jsx
@@ -1,14 +1,13 @@
-import { h } from 'preact';
 import { useState } from 'preact/hooks';
 
 export default function Greeting({messages}) {
 
   const randomMessage = () => messages[(Math.floor(Math.random() * messages.length))];
-  
+
   const [greeting, setGreeting] = useState(messages[0]);
 
   return (
-    <div> 
+    <div>
       <h3>{greeting}! Thank you for visiting!</h3>
       <button onClick={() => setGreeting(randomMessage())}>
         New Greeting

--- a/src/components/ThemeIcon.astro
+++ b/src/components/ThemeIcon.astro
@@ -38,10 +38,11 @@
   }
 </style>
 
-<script>
+<script is:inline>
   const theme = (() => {
-    if (typeof localStorage !== "undefined" && localStorage.getItem("theme")) {
-      return localStorage.getItem("theme") ?? "light";
+    const localStorageTheme = localStorage?.getItem("theme") ?? "";
+    if (["dark", "light"].includes(localStorageTheme)) {
+      return localStorageTheme;
     }
     if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
       return "dark";

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -4,18 +4,18 @@ import { glob } from "astro/loaders";
 import { z, defineCollection } from "astro:content";
 // Define a `loader` and `schema` for each collection
 const blog = defineCollection({
-    loader: glob({ pattern: '**\/[^_]*.md', base: "./src/blog" }),
-    schema: z.object({
-      title: z.string(),
-      pubDate: z.date(),
-      description: z.string(),
-      author: z.string(),
-      image: z.object({
-        url: z.string(),
-        alt: z.string()
-      }),
-      tags: z.array(z.string())
-    })
+  loader: glob({ pattern: "**/[^_]*.md", base: "./src/blog" }),
+  schema: z.object({
+    title: z.string(),
+    pubDate: z.date(),
+    description: z.string(),
+    author: z.string(),
+    image: z.object({
+      url: z.string(),
+      alt: z.string(),
+    }),
+    tags: z.array(z.string()),
+  }),
 });
 // Export a single `collections` object to register your collection(s)
 export const collections = { blog };

--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -2,10 +2,41 @@
 import BaseLayout from "./BaseLayout.astro";
 const { frontmatter } = Astro.props;
 ---
+
 <BaseLayout pageTitle={frontmatter.title}>
-  <p>{frontmatter.pubDate.toString().slice(0,10)}</p>
+  <p>{frontmatter.pubDate.toLocaleDateString()}</p>
   <p><em>{frontmatter.description}</em></p>
   <p>Written by: {frontmatter.author}</p>
   <img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} />
+
+  <div class="tags">
+    {
+      frontmatter.tags.map((tag: string) => (
+        <p class="tag">
+          <a href={`/tags/${tag}`}>{tag}</a>
+        </p>
+      ))
+    }
+  </div>
+
   <slot />
 </BaseLayout>
+<style>
+  a {
+    color: #00539f;
+  }
+
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
+  .tag {
+    margin: 0.25em;
+    border: dotted 1px #a1a1a1;
+    border-radius: 0.5em;
+    padding: 0.5em 1em;
+    font-size: 1.15em;
+    background-color: #f8fcfd;
+  }
+</style>

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -1,17 +1,17 @@
 import rss from "@astrojs/rss";
 import { getCollection } from "astro:content";
 
-export async function GET() {
+export async function GET(context) {
   const posts = await getCollection("blog");
   return rss({
-    title: 'Astro Learner | Blog',
-    description: 'My journey learning Astro',
-    site: 'https://my-blog-site.netlify.app',
+    title: "Astro Learner | Blog",
+    description: "My journey learning Astro",
+    site: context.site,
     items: posts.map((post) => ({
       title: post.data.title,
       pubDate: post.data.pubDate,
       description: post.data.description,
-      link: `/posts/${post.slug}/`,
+      link: `/posts/${post.id}/`,
     })),
     customData: `<language>en-us</language>`,
   });

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,15 +1,16 @@
 ---
+import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 import BlogPost from "../../components/BlogPost.astro";
-import { getCollection } from "astro:content";
 
 export async function getStaticPaths() {
-
   const allPosts = await getCollection("blog");
-  const uniqueTags = [...new Set(allPosts.map((post:any) => post.data.tags).flat())];
+  const uniqueTags = [
+    ...new Set(allPosts.map((post) => post.data.tags).flat()),
+  ];
 
-  return uniqueTags.map((tag:string) => {
-    const filteredPosts = allPosts.filter((post:any) =>
+  return uniqueTags.map((tag) => {
+    const filteredPosts = allPosts.filter((post) =>
       post.data.tags.includes(tag)
     );
     return {
@@ -22,12 +23,13 @@ export async function getStaticPaths() {
 const { tag } = Astro.params;
 const { posts } = Astro.props;
 ---
+
 <BaseLayout pageTitle={tag}>
   <p>Posts tagged with {tag}</p>
   <ul>
     {
-      posts.map((post:any) => (
-        <BlogPost url={"/posts/" + post.slug} title={post.data.title} />
+      posts.map((post) => (
+        <BlogPost url={`/posts/${post.id}/`} title={post.data.title} />
       ))
     }
   </ul>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -2,13 +2,14 @@
 import { getCollection } from "astro:content";
 import BaseLayout from "../../layouts/BaseLayout.astro";
 const allPosts = await getCollection("blog");
-const tags = [...new Set(allPosts.map((post:any) => post.data.tags).flat())];
+const tags = [...new Set(allPosts.map((post) => post.data.tags).flat())];
 const pageTitle = "Tag Index";
 ---
+
 <BaseLayout pageTitle={pageTitle}>
   <div class="tags">
     {
-      tags.map((tag:string) => (
+      tags.map((tag) => (
         <p class="tag">
           <a href={`/tags/${tag}`}>{tag}</a>
         </p>
@@ -24,7 +25,6 @@ const pageTitle = "Tag Index";
   .tags {
     display: flex;
     flex-wrap: wrap;
-    margin: 0 auto;
   }
 
   .tag {


### PR DESCRIPTION
I followed the [tutorial](https://docs.astro.build/en/tutorial/0-introduction/) in Astro Docs to check if we missed some updates. I first updated the `complete` branch (see #39). Now it's time to do the same with `content-collections`:

* Updates the dependencies (we were still using the beta version)
* Removes the `start` script which was removed with Astro 5
* Adds `@ts-check` in `astro.config.mjs` since this is now added by default when creating a new project
* Fixes some remaining `.slug` instead of `.id`
* Updates the images URL and alt description in `src/blog` to match the ones used in the docs
* Adds missing tags in `MarkdownPostLayout.astro`
* Removes some unnecessary escape characters, types, styles (no longer in the docs)
* Converts the `Greeting` component to JSX (instead of TSX) to prevent a Typescript error and to match the extension used in the docs
* Adds changes submitted in #38 to `ThemeIcon` and adds a missing `is:inline` directive on the script

I disabled Prettier for the workspace but there was still some formatting when saving the files...

This should now match what we get at the end of the tutorial! 🎉 